### PR TITLE
Built-in call for date variable added. Fixed format exception.

### DIFF
--- a/debugger.ftl
+++ b/debugger.ftl
@@ -431,7 +431,7 @@
     <#-- DATE -->
     <#-- TODO: format -->
     <#elseif value?is_date>
-      date: ${value}
+      date: ${value?date}
 
     <#-- BOOLEAN -->
     <#elseif value?is_boolean>


### PR DESCRIPTION
When you call a date without the built-in, FreeMarker doesn't know how to interpret string representation.
